### PR TITLE
Add default epic to P2P failure rules

### DIFF
--- a/firewatch-base-configs/rosa/p2p-msi.json
+++ b/firewatch-base-configs/rosa/p2p-msi.json
@@ -1,17 +1,17 @@
 {
   "failure_rules":
   [
-    {"step": "aws-provision*", "failure_type": "all", "classification": "Infrastructure Provisioning - AWS", "group": {"name": "cluster", "priority": 1}, "jira_additional_labels": ["!default"]},
-    {"step": "aws-deprovision*", "failure_type": "all", "classification": "Infrastructure Deprovisioning - AWS", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
-    {"step": "osd-*", "failure_type": "all", "classification": "Other", "group": {"name": "cluster", "priority": 3}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-cluster-provision", "failure_type": "all", "classification": "Infrastructure Provisioning - Cluster", "group": {"name": "cluster", "priority": 1}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-cluster-deprovision", "failure_type": "all", "classification": "Infrastructure Deprovisioning - Cluster", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-cluster-wait*", "failure_type": "all", "classification": "Infrastructure Provisioning - Rosa Cluster Operators", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-sts-account-roles-create", "failure_type": "all", "classification": "Account Roles Creation - AWS", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-sts-account-roles-delete", "failure_type": "all", "classification": "Account Roles Deletion - AWS", "group": {"name": "cluster", "priority": 3}, "jira_additional_labels": ["!default"]},
-    {"step": "rosa-conf-idp-htpasswd", "failure_type": "all", "classification": "Admin Access - Cluster", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
-    {"step": "gather-*", "failure_type": "pod_failure", "classification": "Other", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"]},
+    {"step": "aws-provision*", "failure_type": "all", "classification": "Infrastructure Provisioning - AWS", "group": {"name": "cluster", "priority": 1}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "aws-deprovision*", "failure_type": "all", "classification": "Infrastructure Deprovisioning - AWS", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "osd-*", "failure_type": "all", "classification": "Other", "group": {"name": "cluster", "priority": 3}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-cluster-provision", "failure_type": "all", "classification": "Infrastructure Provisioning - Cluster", "group": {"name": "cluster", "priority": 1}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-cluster-deprovision", "failure_type": "all", "classification": "Infrastructure Deprovisioning - Cluster", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-cluster-wait*", "failure_type": "all", "classification": "Infrastructure Provisioning - Rosa Cluster Operators", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-sts-account-roles-create", "failure_type": "all", "classification": "Account Roles Creation - AWS", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-sts-account-roles-delete", "failure_type": "all", "classification": "Account Roles Deletion - AWS", "group": {"name": "cluster", "priority": 3}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "rosa-conf-idp-htpasswd", "failure_type": "all", "classification": "Admin Access - Cluster", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
+    {"step": "gather-*", "failure_type": "pod_failure", "classification": "Other", "group": {"name": "cluster", "priority": 2}, "jira_additional_labels": ["!default"], "jira_epic": "!default"},
     {"step": "gather-*", "failure_type": "test_failure", "classification": "NONE", "jira_project": "NONE", "ignore": "true"},
-    {"step": "operator-install*", "failure_type": "all", "classification": "Infrastructure Provisioning - Operators", "group": {"name": "p2p-tests", "priority": 1}, "jira_additional_labels": ["!default"]}
+    {"step": "operator-install*", "failure_type": "all", "classification": "Infrastructure Provisioning - Operators", "group": {"name": "p2p-tests", "priority": 1}, "jira_additional_labels": ["!default"], "jira_epic": "!default"}
   ]
 }


### PR DESCRIPTION
Adding the jira_epic value to all failure rules to point to the default epic.