### PR TITLE
POC: Add aws-ipi project base config file

### DIFF
--- a/firewatch-base-configs/aws-ipi/project_base_config.yaml
+++ b/firewatch-base-configs/aws-ipi/project_base_config.yaml
@@ -1,9 +1,9 @@
 ---
-FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
-FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.19-lp","self-managed-lp"]'
-FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
-FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
-transition_map:
+DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.19-lp","self-managed-lp"]'
+DEFAULT_JIRA_PROJECT: LPINTEROP
+rules_config_path: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
+fail_with_test_failure: "true"
+jira_transition_map:
   LPINTEROP: PASS
   CSPIT: PASS
   OCSQE: DONE

--- a/firewatch-base-configs/aws-ipi/project_base_config.yaml
+++ b/firewatch-base-configs/aws-ipi/project_base_config.yaml
@@ -1,0 +1,11 @@
+---
+FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
+FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.19-lp","self-managed-lp"]'
+FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
+transition_map:
+  LPINTEROP: PASS
+  CSPIT: PASS
+  OCSQE: DONE
+  DEFAULT: CLOSED
+

--- a/firewatch-base-configs/project_transition_map.json
+++ b/firewatch-base-configs/project_transition_map.json
@@ -1,6 +1,0 @@
-{
-    "LPINTEROP": "PASS",
-    "CSPIT": "PASS",
-    "OCSQE": "DONE",
-    "DEFAULT": "CLOSED"
-  }


### PR DESCRIPTION
Main changes:

- Config transition map within the project config instead of a raw file
- Set all project env vars in the file instead of the job's config file
